### PR TITLE
Handle CameraX initialization failures gracefully

### DIFF
--- a/qrscanner-compose/src/main/java/ch/ubique/qrscanner/compose/QrScanner.kt
+++ b/qrscanner-compose/src/main/java/ch/ubique/qrscanner/compose/QrScanner.kt
@@ -20,10 +20,12 @@ import androidx.core.hardware.display.DisplayManagerCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import ch.ubique.qrscanner.scanner.ImageAnalyzer
+import ch.ubique.qrscanner.scanner.CameraErrorCallback
 import ch.ubique.qrscanner.scanner.ImageDecoder
 import ch.ubique.qrscanner.scanner.QrScannerCallback
 import ch.ubique.qrscanner.scanner.ScanningMode
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 @Composable
@@ -34,6 +36,7 @@ fun QrScanner(
 	scanningMode: ScanningMode = ScanningMode.PARALLEL,
 	isFlashEnabled: State<Boolean> = remember { mutableStateOf(false) },
 	linearZoom: State<Float> = remember { mutableFloatStateOf(0f) },
+	cameraErrorCallback: CameraErrorCallback? = null,
 ) {
 	val context = LocalContext.current
 	val lifecycleOwner = LocalLifecycleOwner.current
@@ -76,15 +79,25 @@ fun QrScanner(
 	val previewView = remember { PreviewView(context) }
 
 	LaunchedEffect(previewView) {
-		val cameraProvider = suspendCoroutine<ProcessCameraProvider> { continuation ->
-			val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
-			cameraProviderFuture.addListener({
-				continuation.resume(cameraProviderFuture.get())
-			}, mainExecutor)
+		try {
+			val cameraProvider = suspendCoroutine<ProcessCameraProvider> { continuation ->
+				val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+				cameraProviderFuture.addListener({
+					runCatching {
+						cameraProviderFuture.get()
+					}.onSuccess(continuation::resume)
+						.onFailure { exception ->
+							continuation.resumeWithException(exception.cause ?: exception)
+						}
+				}, mainExecutor)
+			}
+			cameraProvider.unbindAll()
+			camera.value = cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, imageAnalysis)
+			preview.setSurfaceProvider(previewView.surfaceProvider)
+		} catch (throwable: Throwable) {
+			camera.value = null
+			cameraErrorCallback?.onCameraError(throwable)
 		}
-		cameraProvider.unbindAll()
-		camera.value = cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, imageAnalysis)
-		preview.setSurfaceProvider(previewView.surfaceProvider)
 	}
 
 	LaunchedEffect(isFlashEnabled.value) {

--- a/qrscanner-core/src/main/java/ch/ubique/qrscanner/scanner/CameraErrorCallback.kt
+++ b/qrscanner-core/src/main/java/ch/ubique/qrscanner/scanner/CameraErrorCallback.kt
@@ -1,0 +1,5 @@
+package ch.ubique.qrscanner.scanner
+
+fun interface CameraErrorCallback {
+	fun onCameraError(throwable: Throwable)
+}

--- a/qrscanner-core/src/main/java/ch/ubique/qrscanner/view/QrScannerView.kt
+++ b/qrscanner-core/src/main/java/ch/ubique/qrscanner/view/QrScannerView.kt
@@ -65,6 +65,7 @@ class QrScannerView @JvmOverloads constructor(
 	private var scannerCallback: QrScannerCallback? = null
 	private var scanningMode = ScanningMode.PARALLEL
 	private var cameraStateCallback: CameraStateCallback? = null
+	private var cameraErrorCallback: CameraErrorCallback? = null
 
 	var isCameraActive = false
 		private set
@@ -114,19 +115,21 @@ class QrScannerView @JvmOverloads constructor(
 
 		val lifecycleOwner = viewTreeLifecycleOwner ?: return
 		cameraProviderFuture.addListener({
-			val cameraProvider = cameraProviderFuture.get()
+			runCatching {
+				val cameraProvider = cameraProviderFuture.get()
 
-			val cameraSelector = CameraSelector.Builder()
-				.requireLensFacing(CameraSelector.LENS_FACING_BACK)
-				.build()
+				val cameraSelector = CameraSelector.Builder()
+					.requireLensFacing(CameraSelector.LENS_FACING_BACK)
+					.build()
 
-			// Since the CameraProvider is a singleton and will return the same instance across multiple invocations, any other view
-			// that has binded to that camera provider without unbinding will cause this view to throw an exception when trying to bind to the lifecycle.
-			// This might happen e.g. if the camera view is used within a RecyclerView and an old view holder has not finished
-			// calling deactivateCamera() before the new view holder already calls activateCamera()
-			cameraProvider.unbindAll()
-			camera = cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, imageAnalysis)
-			setCameraState(true)
+				// Since the CameraProvider is a singleton and will return the same instance across multiple invocations, any other view
+				// that has binded to that camera provider without unbinding will cause this view to throw an exception when trying to bind to the lifecycle.
+				// This might happen e.g. if the camera view is used within a RecyclerView and an old view holder has not finished
+				// calling deactivateCamera() before the new view holder already calls activateCamera()
+				cameraProvider.unbindAll()
+				camera = cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, imageAnalysis)
+				setCameraState(true)
+			}.onFailure(::handleCameraError)
 		}, mainExecutor)
 	}
 
@@ -137,9 +140,11 @@ class QrScannerView @JvmOverloads constructor(
 		if (!isCameraActive) return
 
 		cameraProviderFuture.addListener({
-			val cameraProvider = cameraProviderFuture.get()
-			cameraProvider.unbindAll()
-			setCameraState(false)
+			runCatching {
+				val cameraProvider = cameraProviderFuture.get()
+				cameraProvider.unbindAll()
+				setCameraState(false)
+			}.onFailure(::handleCameraError)
 		}, mainExecutor)
 	}
 
@@ -157,6 +162,13 @@ class QrScannerView @JvmOverloads constructor(
 	fun setCameraStateCallback(callback: CameraStateCallback) {
 		this.cameraStateCallback = callback
 		callback.onCameraStateChanged(isCameraActive)
+	}
+
+	/**
+	 * Set a callback to be notified when camera initialization or binding fails.
+	 */
+	fun setCameraErrorCallback(callback: CameraErrorCallback?) {
+		this.cameraErrorCallback = callback
 	}
 
 	/**
@@ -264,6 +276,12 @@ class QrScannerView @JvmOverloads constructor(
 	private fun setCameraState(isActive: Boolean) {
 		this.isCameraActive = isActive
 		cameraStateCallback?.onCameraStateChanged(isActive)
+	}
+
+	private fun handleCameraError(throwable: Throwable) {
+		camera = null
+		setCameraState(false)
+		cameraErrorCallback?.onCameraError(throwable.cause ?: throwable)
 	}
 
 }


### PR DESCRIPTION
This PR improves CameraX initialization and should fix the following crashes:

```
Exception java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:602)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:952)
Caused by java.lang.reflect.InvocationTargetException:
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:592)
Caused by java.util.concurrent.ExecutionException:
  at androidx.concurrent.futures.AbstractResolvableFuture.getDoneValue (AbstractResolvableFuture.java:518)
  at androidx.concurrent.futures.AbstractResolvableFuture.get (AbstractResolvableFuture.java:475)
  at androidx.concurrent.futures.CallbackToFutureAdapter$SafeFuture.get (CallbackToFutureAdapter.java:199)
  at androidx.camera.core.impl.utils.futures.FutureChain.get (FutureChain.java:155)
  at androidx.camera.core.impl.utils.futures.ChainingListenableFuture.get (ChainingListenableFuture.java:105)
  at ch.ubique.qrscanner.compose.QrScannerKt$QrScanner$3$1$cameraProvider$1$1.run (QrScanner.kt:82)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7697)
  ```